### PR TITLE
Add `SELECT` function selection to 1D, 2D, SET and TEST scenarios.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ else()
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${nested_fit_target}> $ENV{HOME}/bin)
 
     add_custom_command(TARGET ${nested_fit_target_func} POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${nested_fit_target}_func> $ENV{HOME}/bin)
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${nested_fit_target_func}> $ENV{HOME}/bin)
 
     # Since we do this for the nested fit executable, why not put the latest nested_res_* file in the bin
     # At least while we don't have a custom python caller script

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,8 +14,8 @@ set(project_version 4.4.0)
 # Global options
 option(DEBUG "Enable debug mode." OFF)
 option(NORNG "Uses the same set seed. Useful for testing." OFF)
-# option(MOD_TEST "Uses another likelihood function." OFF)
-option(OPENMP "Enable/Disable OpenMP." OFF) # This replaced the manual parallel_on variable on the nested_fit.f90 file
+
+option(OPENMP "Enable/Disable OpenMP." OFF)
 option(OPENMPI "Enable/Disable OpenMPI." OFF)
 option(AUTOTESTS "Automatically run tests after compiling." OFF)
 
@@ -62,7 +62,6 @@ set(SRC_FILES_COMM
 )
 
 set(SRC_FILES_DATA
-
     src/Mod_likelihood.f90
 
     src/USERFCN_2D.f90
@@ -71,7 +70,6 @@ set(SRC_FILES_DATA
 )
 
 set(SRC_FILES_FUNC
-
     src/Mod_likelihood_tests.f90
 )
 
@@ -82,7 +80,7 @@ set(CHILD_SRC_FILES
 
 file(GLOB SRC_CALGO   ${CMAKE_SOURCE_DIR}/src/CALGO.ACM/*.f)
 file(GLOB SRC_DIERCKX ${CMAKE_SOURCE_DIR}/src/DIERCKX/*.f)
-file(GLOB SRC_SLATEC ${CMAKE_SOURCE_DIR}/src/SLATEC/*.f)
+file(GLOB SRC_SLATEC  ${CMAKE_SOURCE_DIR}/src/SLATEC/*.f)
 
 if(OPENMP AND OPENMPI)
     message(ERROR "Compiling against OpenMP and OpenMPI at the same time is currently not supported.")
@@ -140,6 +138,8 @@ set_source_files_properties(${CFG_FILES} PROPERTIES COMPILE_FLAGS ${SRC_FLAGS})
 set_source_files_properties(${CHILD_SRC_FILES} PROPERTIES COMPILE_FLAGS ${SRC_FLAGS})
 
 string(CONCAT nested_fit_target "nested_fit" ${nested_fit_version_full_str})
+string(CONCAT nested_fit_target_func "nested_fit_func" ${nested_fit_version_full_str})
+
 add_executable(${nested_fit_target}
     ${CFG_FILES}
     ${SRC_CALGO}
@@ -149,7 +149,7 @@ add_executable(${nested_fit_target}
     ${SRC_FILES_DATA}
 )
 
-add_executable(${nested_fit_target}_func
+add_executable(${nested_fit_target_func}
     ${CFG_FILES}
     ${SRC_CALGO}
     ${SRC_DIERCKX}
@@ -166,7 +166,8 @@ if(OPENMPI)
 endif()
 
 if(OPENMP)
-    target_link_options(${nested_fit_target} PRIVATE "-fopenmp")
+    target_link_options(${nested_fit_target}      PRIVATE "-fopenmp")
+    target_link_options(${nested_fit_target_func} PRIVATE "-fopenmp")
 endif()
 
 # TODO(César): MPI is needed even for non-MPI builds, since the source code is runtime selecting mpi funcitonality based on a PARAMETER
@@ -175,8 +176,8 @@ endif()
 find_package(MPI REQUIRED)
 if(MPI_FOUND)
     if(MPI_Fortran_HAVE_F90_MODULE)
-        target_link_libraries(${nested_fit_target} PUBLIC MPI::MPI_Fortran)
-        target_link_libraries(${nested_fit_target}_func PUBLIC MPI::MPI_Fortran)
+        target_link_libraries(${nested_fit_target}      PUBLIC MPI::MPI_Fortran)
+        target_link_libraries(${nested_fit_target_func} PUBLIC MPI::MPI_Fortran)
         if(OPENMPI)
             target_link_libraries(${nested_fit_mpi_child_comm_proc_name} PUBLIC MPI::MPI_Fortran)
         endif()
@@ -199,7 +200,7 @@ else()
     add_custom_command(TARGET ${nested_fit_target} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${nested_fit_target}> $ENV{HOME}/bin)
 
-    add_custom_command(TARGET ${nested_fit_target}_func POST_BUILD
+    add_custom_command(TARGET ${nested_fit_target_func} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${nested_fit_target}_func> $ENV{HOME}/bin)
 
     # Since we do this for the nested fit executable, why not put the latest nested_res_* file in the bin

--- a/README.md
+++ b/README.md
@@ -43,15 +43,18 @@ mkdir build && cd build
 cmake ..
 make
 ```
-> :warning: For Windows you can compile by replacing line of the above commands by `cmake -G"MinGW Makefiles" ..`, for simplicity.
+> :warning: For Windows you can compile by replacing the second line of the above commands with `cmake -G"MinGW Makefiles" ..`, for simplicity.
 
 **CMake options**
 
-| Option | Description                                           | Default |
-|:-------|:------------------------------------------------------|:-------:|
-|DEBUG   | "Enable debug mode."                                  | OFF     |
-|NORNG   | "Uses the tests functions instead of the likelihood." | OFF     |
-|OPENMP  | "Enable/Disable OpenMP."                              | OFF     |
+| Option   | Description                                                     | Default |
+|:---------|:----------------------------------------------------------------|:-------:|
+|DEBUG     | Enable debug mode.                                              | OFF     |
+|NORNG     | Set the nested_fit to use a set seed. Internal test use mainly. | OFF     |
+|OPENMP    | Enable/Disable OpenMP support.                                  | OFF     |
+|OPENMPI   | Enable/Disable OpenMPI support.                                 | OFF     |
+|AUTOTESTS | Automatically run tests after compiling.                        | OFF     |
+
 
 
 > You can pass in options on the cmake step via: `cmake -D<option_name>=<ON/OFF> ..`\
@@ -85,7 +88,7 @@ Together with this file, also the files `nf_output_points.paramnames` and `nf_ou
 
 **Details of the input file line by line**
 ```
-4.3                 # Program version
+4.4                 # Program version
 he-histo.dat        # Name of the (first) data file
 n                   # Set of files (y/n)
 1c                  # Type of data: error bars or not and dimensions (1c,1e,2c,2s,2e)
@@ -155,12 +158,18 @@ Additional information can be found in the reference articles.
 
 ## Present version and history of the past versions
 
-The present version is 4.3.1
+The present version is 4.4.0
 New features:
-- New (test) function : harmonic potential in 3D and loggamma
-- Choice between different convergence methods : evidence or partition function  
+- OpenMPI support (only available for number of tries)
+- New user function calling method
+- Add Windows support
+- New build system generator (CMake)
+- Improved performance
+
 
 Previous versions are:
+ - 4.3 New (test) function : harmonic potential in 3D and loggamma \
+ Choice between different convergence methods : evidence or partition function  
  - 4.2 Additional search methods : Uniform search around each live point and Slice Sampling
  - 4.1.1 New cluster recognition methods added
  - 4.0.3 2D data analysis for count-type XY \

--- a/src/Mod_likelihood.f90
+++ b/src/Mod_likelihood.f90
@@ -324,17 +324,9 @@ CONTAINS
 #define BIT_CHECK_IF(what) IAND(dataid, what).GT.0
   
   SUBROUTINE INIT_FUNCTIONS()
-    ! Subroutine to initialize the user functions and functions id
+    ! Subroutine to initialize the user functions, functions id and data ids
 
-
-    INTEGER(4) :: SELECT_USERFCN, SELECT_USERFCN_SET
-
-    ! Init the funcid for function names
-    IF(set_yn.EQ.'n') THEN
-       funcid = SELECT_USERFCN(funcname)
-    ELSE
-       funcid = SELECT_USERFCN_SET(funcname)
-    END IF
+    INTEGER(4) :: SELECT_USERFCN, SELECT_USERFCN_SET, SELECT_USERFCN_2D
 
     ! Init the dataid for data types !
     ! ------------------------------ !
@@ -367,6 +359,22 @@ CONTAINS
     ! Is this a set ?
     IF(set_yn.EQ.'y'.OR.set_yn.EQ.'Y') THEN
        dataid = IOR(dataid, DATA_IS_SET)
+    END IF
+
+
+    ! Init the funcid for function names
+    IF(.NOT.(BIT_CHECK_IF(DATA_IS_SET))) THEN
+       IF(BIT_CHECK_IF(DATA_IS_1D)) THEN
+          funcid = SELECT_USERFCN(funcname)
+       ELSE
+          funcid = SELECT_USERFCN_2D(funcname)
+       END IF
+    ELSE
+       IF(BIT_CHECK_IF(DATA_IS_2D)) THEN
+          WRITE(*,*) 'Sets for 2D functions are not yet implemented.'
+          STOP
+       END IF
+       funcid = SELECT_USERFCN_SET(funcname)
     END IF
 
     ! Initialise functions if needed
@@ -417,9 +425,7 @@ CONTAINS
     ELSE IF (BIT_CHECK_IF(DATA_IS_2D)) THEN
        LOGLIKELIHOOD = LOGLIKELIHOOD_2D(par)
     END IF
-
-
-
+    
   END FUNCTION LOGLIKELIHOOD
 
   !#####################################################################################################################
@@ -570,7 +576,7 @@ CONTAINS
           ! Poisson distribution calculation --------------------------------------------------
           xx = i - 0.5 + xmin(k) ! Real coordinates are given by the bins, the center of the bin.
           yy = j - 0.5 + ymin(k) ! additional -1 to take well into account xmin,ymin
-          enc = USERFCN_2D(xx,yy,npar,par,funcname)
+          enc = USERFCN_2D(xx,yy,npar,par,funcid)
           ll_tmp = ll_tmp + adata_mask(i,j)*(adata(i,j)*DLOG(enc) - enc)
        END DO
     END DO

--- a/src/Mod_likelihood.f90
+++ b/src/Mod_likelihood.f90
@@ -339,8 +339,8 @@ CONTAINS
     ! ------------------------------ !
     ! ud = undefined (space for a 3d analysis [b6] and other distributions [b2, b3])
     ! yn = 0/1 -> n/y
-    ! TODO: The e/c 1/2 could live in the same bit, making comparisons even faster
-    ! TODO: But there wouldn't be much space for working with other values in the future
+    ! TODO(Cesar): The e/c 1/2 could live in the same bit, making comparisons even faster
+    ! TODO(Cesar): But there wouldn't be much space for working with other values in the future
     
     ! Is the data 1 or 2-D ?
     IF(data_type(1:1).EQ.'1') THEN
@@ -455,7 +455,7 @@ CONTAINS
                 WRITE(*,*) 'LIKELIHOOD ERROR: put a background in your function'
                 WRITE(*,*) 'number of counts different from 0, model prediction equal 0 or less'
                 WRITE(*,*) 'Function value = ', enc, ' n. counts = ', nc(i,k)
-                STOP ! TODO: Handle all of these errors for the case of MPI
+                STOP ! TODO(Cesar): Handle all of these errors for the case of MPI
              END IF
           END DO
        END DO

--- a/src/Mod_likelihood_tests.f90
+++ b/src/Mod_likelihood_tests.f90
@@ -2,19 +2,9 @@ MODULE MOD_LIKELIHOOD
   ! Automatic Time-stamp: <Last changed by martino on Monday 03 May 2021 at CEST 13:23:14>
   ! Module of likelihood test function, no real data are involved here
 
-
-
   !#####################################################################################################################
 
-  ! IMPORTANT: to switch between likelihood types for test and others,
-  ! change the name of the file to compile in the Makefile,
-  ! Mod_likeihood.f90 or Mod_likeihood_tests.f90
-
-  !#####################################################################################################################
-
-  !#####################################################################################################################
-
-  ! OTHER IMPORTANT NOTE: because of the intrinsic construction of nested samplig, change of range can change the result
+  ! IMPORTANT NOTE: because of the intrinsic construction of nested samplig, change of range can change the result
   ! It is the case also in Polychord. In polychord you change the sigma, it is not changing the result. In Nested Fit,
   ! the search algorithm has to be optimized. FA CACARE!!!! NON FUNZIONA !!!!?????
 
@@ -56,7 +46,7 @@ CONTAINS
   END FUNCTION LOGLIKELIHOOD_WITH_TEST
 
   !------------------------------------------------------------------------------------------------------------------------
-
+  ! TODO(Cesar): In reality this should be in another file, but I am following the previous "rules"
 
   REAL(8) FUNCTION LOGLIKELIHOOD(par)
     ! Main likelihood function

--- a/src/Mod_likelihood_tests.f90
+++ b/src/Mod_likelihood_tests.f90
@@ -12,7 +12,7 @@ MODULE MOD_LIKELIHOOD
 
 
   ! Module for the input parameter definition
-  USE MOD_PARAMETERS, ONLY: npar, funcname
+  USE MOD_PARAMETERS, ONLY: npar, funcname, funcid
 
   IMPLICIT NONE
   INTEGER(8) :: ncall=0
@@ -29,6 +29,8 @@ CONTAINS
     !IF (funcname.eq.'TEST_ROSENBROCK') THEN
     !   CALL INIT_ROSENBROCK()
     !END IF
+    
+    funcid = SELECT_LIKELIHOODFCN(funcname)
 
   END SUBROUTINE INIT_LIKELIHOOD
 
@@ -46,7 +48,36 @@ CONTAINS
   END FUNCTION LOGLIKELIHOOD_WITH_TEST
 
   !------------------------------------------------------------------------------------------------------------------------
-  ! TODO(Cesar): In reality this should be in another file, but I am following the previous "rules"
+  ! TODO(Cesar): In reality this should be in another file, but I am following the previous "rules"...
+  FUNCTION SELECT_LIKELIHOODFCN(funcname)
+    IMPLICIT NONE
+    INTEGER*4 SELECT_LIKELIHOODFCN
+    CHARACTER*64 funcname
+
+    IF (funcname.eq.'TEST_SIMPLE_GAUSS') THEN
+      SELECT_LIKELIHOODFCN = 0
+    ELSE IF (funcname.eq.'TEST_GAUSS') THEN
+      SELECT_LIKELIHOODFCN = 1
+    ELSE IF (funcname.eq.'TEST_GAUSSIAN_SHELLS') THEN
+      SELECT_LIKELIHOODFCN = 2
+    ELSE IF (funcname.eq.'TEST_EGGBOX') THEN
+      SELECT_LIKELIHOODFCN = 3
+    ELSE IF (funcname.eq.'TEST_ROSENBROCK') THEN
+      SELECT_LIKELIHOODFCN = 4
+    ELSE IF (funcname.eq.'TEST_GAUSS_WITH_CORRELATION') THEN
+      SELECT_LIKELIHOODFCN = 5
+    ELSE IF(funcname.eq.'ENERGY_HARM_3D') THEN
+      SELECT_LIKELIHOODFCN = 6
+    ELSE IF(funcname.eq.'TEST_LOGGAMMA') THEN
+      SELECT_LIKELIHOODFCN = 7
+    ELSE
+       WRITE(*,*) 'Error of the function name in Mod_likelihood_test module'
+       WRITE(*,*) 'Check the manual and the input file'
+       STOP
+    END IF
+
+    RETURN
+  END
 
   REAL(8) FUNCTION LOGLIKELIHOOD(par)
     ! Main likelihood function
@@ -56,27 +87,24 @@ CONTAINS
     ncall = ncall + 1
 
     ! Select the test function
-    IF (funcname.eq.'TEST_SIMPLE_GAUSS') THEN
+    SELECT CASE (funcid)
+    CASE (0)
        LOGLIKELIHOOD = TEST_SIMPLE_GAUSS(par)
-    ELSE IF (funcname.eq.'TEST_GAUSS') THEN
+    CASE (1)
        LOGLIKELIHOOD = TEST_GAUSS(par)
-    ELSE IF (funcname.eq.'TEST_GAUSSIAN_SHELLS') THEN
+    CASE (2)
        LOGLIKELIHOOD = TEST_GAUSSIAN_SHELLS(par)
-    ELSE IF (funcname.eq.'TEST_EGGBOX') THEN
+    CASE (3)
        LOGLIKELIHOOD = TEST_EGGBOX(par)
-    ELSE IF (funcname.eq.'TEST_ROSENBROCK') THEN
+    CASE (4)
        LOGLIKELIHOOD = TEST_ROSENBROCK(par)
-    ELSE IF (funcname.eq.'TEST_GAUSS_WITH_CORRELATION') THEN
-       LOGLIKELIHOOD=TEST_GAUSS_WITH_CORRELATION(par)
-    ELSE IF(funcname.eq.'ENERGY_HARM_3D') THEN
-       LOGLIKELIHOOD=ENERGY_HARM_3D(par)
-    ELSE IF(funcname.eq.'TEST_LOGGAMMA') THEN
-       LOGLIKELIHOOD=TEST_LOGGAMMA(par)
-    ELSE
-       WRITE(*,*) 'Error of the function name in Mod_likelihood_test module'
-       WRITE(*,*) 'Check the manual and the input file'
-       STOP
-    END IF
+    CASE (5)
+       LOGLIKELIHOOD = TEST_GAUSS_WITH_CORRELATION(par)
+    CASE (6)
+       LOGLIKELIHOOD = ENERGY_HARM_3D(par)
+    CASE (7)
+       LOGLIKELIHOOD = TEST_LOGGAMMA(par)
+    END SELECT
 
 
   END FUNCTION LOGLIKELIHOOD

--- a/src/Mod_parameters.f90
+++ b/src/Mod_parameters.f90
@@ -30,6 +30,7 @@ MODULE MOD_PARAMETERS
 
   ! Calculated variables
   INTEGER(4) :: funcid=0
+  INTEGER(4) :: dataid=0
 
 
   COMMON /func_exp/ lr

--- a/src/USERFCN_2D.f90
+++ b/src/USERFCN_2D.f90
@@ -1,13 +1,54 @@
 ! Time-stamp: <Last changed by martino on Monday 21 June 2021 at CEST 17:56:10>
 
-REAL(8) FUNCTION USERFCN_2D(x,y,npar,val,funcname)
+FUNCTION SELECT_USERFCN_2D(funcname)
+   IMPLICIT NONE
+   CHARACTER*64 funcname
+   INTEGER*4 SELECT_USERFCN_2D
+
+   ! Choose your model (see below for definition)
+   IF(funcname.EQ.'GAUSS_SIMPLE_2D') THEN
+      SELECT_USERFCN_2D = 0
+   ELSE IF(funcname.EQ.'GAUSS_BG_2D') THEN
+      SELECT_USERFCN_2D = 1
+   ELSE IF(funcname.EQ.'GAUSS_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 2
+   ELSE IF(funcname.EQ.'LORE_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 3
+   ELSE IF(funcname.EQ.'VOIGT_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 4
+   ELSE IF(funcname.EQ.'SUPERGAUSS_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 5
+   ELSE IF(funcname.EQ.'ERFPEAK_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 6
+   ELSE IF(funcname.EQ.'TWO_ERFPEAK_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 7
+   ELSE IF(funcname.EQ.'TWO_LORE_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 8
+   ELSE IF(funcname.EQ.'TWO_LORE_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 9
+   ELSE IF(funcname.EQ.'TWO_LORE_WF_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 10
+   ELSE IF(funcname.EQ.'FOUR_LORE_WF_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 11
+   ELSE IF(funcname.EQ.'TWO_VOIGT_LINE_BG_2D') THEN
+      SELECT_USERFCN_2D = 12
+   ELSE
+      WRITE(*,*) 'Selected function:', funcname
+      WRITE(*,*) 'Error in the function name def. in SELECT_USERFCN_2D'
+      WRITE(*,*) 'Check in the manual and in the input.dat file'
+      STOP
+   END IF
+   RETURN
+END
+
+REAL(8) FUNCTION USERFCN_2D(x,y,npar,val,funcid)
   ! Library of 2D functions
 
   IMPLICIT NONE
   REAL(8), INTENT(IN) :: x, y
   INTEGER(4), INTENT(IN) :: npar
   REAL(8), DIMENSION(npar), INTENT(IN) :: val
-  CHARACTER, INTENT(IN) :: funcname*64
+  INTEGER(4), INTENT(IN) :: funcid
   !
   REAL(8) :: GAUSS_SIMPLE_2D, GAUSS_BG_2D
   REAL(8) :: GAUSS_LINE_BG_2D, SUPERGAUSS_LINE_BG_2D
@@ -17,36 +58,34 @@ REAL(8) FUNCTION USERFCN_2D(x,y,npar,val,funcname)
   REAL(8) :: FOUR_LORE_WF_LINE_BG_2D
 
   ! Choose your model (see below for definition)
-  IF(funcname.EQ.'GAUSS_SIMPLE_2D') THEN
+  SELECT CASE (funcid)
+  CASE (0)
      USERFCN_2D = GAUSS_SIMPLE_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'GAUSS_BG_2D') THEN
+  CASE(1)
      USERFCN_2D = GAUSS_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'GAUSS_LINE_BG_2D') THEN
+  CASE(2)
      USERFCN_2D = GAUSS_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'LORE_LINE_BG_2D') THEN
+  CASE(3)
      USERFCN_2D = LORE_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'VOIGT_LINE_BG_2D') THEN
+  CASE(4)
      USERFCN_2D = VOIGT_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'SUPERGAUSS_LINE_BG_2D') THEN
+  CASE(5)
      USERFCN_2D = SUPERGAUSS_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'ERFPEAK_LINE_BG_2D') THEN
+  CASE(6)
      USERFCN_2D = ERFPEAK_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'TWO_ERFPEAK_LINE_BG_2D') THEN
+  CASE(7)
      USERFCN_2D = TWO_ERFPEAK_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'TWO_LORE_LINE_BG_2D') THEN
+  CASE(8)
      USERFCN_2D = TWO_LORE_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'TWO_LORE_LINE_BG_2D') THEN
+  CASE(9)
      USERFCN_2D = TWO_LORE_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'TWO_LORE_WF_LINE_BG_2D') THEN
+  CASE(10)
      USERFCN_2D = TWO_LORE_WF_LINE_BG_2D(x,y,npar,val)
-  ELSE IF(funcname.EQ.'FOUR_LORE_WF_LINE_BG_2D') THEN
-     USERFCN_2D = FOUR_LORE_WF_LINE_BG_2D(x,y,npar,val)
-  ELSE
-     WRITE(*,*) 'Error in the function name def. in USERFCN_2D'
-     WRITE(*,*) 'Check in the manual and in the nf_input.dat file'
-     STOP
-  END IF
-
+   CASE(11)
+      USERFCN_2D = FOUR_LORE_WF_LINE_BG_2D(x,y,npar,val)
+   CASE(12)
+      USERFCN_2D = TWO_VOIGT_LINE_BG_2D(x,y,npar,val)
+  END SELECT
 
   RETURN
 

--- a/src/nested_fit.f90
+++ b/src/nested_fit.f90
@@ -273,7 +273,7 @@ PROGRAM NESTED_FIT
          IF (par_bnd1(i).GE.par_bnd2(i)) THEN
             WRITE(*,*) 'Bad limits in parameter n.', i, ' (low bound1 >= high bound!!!) Change it and restart'
             WRITE(*,*) 'Low bound:',par_bnd1(i), 'High bound:', par_bnd2(i)
-            ! TODO: Change this to work with defines instead
+            ! TODO(Cesar): Change this to work with defines instead
             IF(parallel_mpi_on) THEN
                CALL MPI_Abort(MPI_COMM_WORLD, 1, mpi_ierror)
             ENDIF

--- a/src/nested_fit.f90
+++ b/src/nested_fit.f90
@@ -2,6 +2,10 @@ PROGRAM NESTED_FIT
   ! Time-stamp: <Last changed by martino on Monday 07 June 2021 at CEST 10:29:22>
   !
   ! Please read README and LICENSE files for more inforamtion
+  ! 4.4  OpenMPI support (only available for number of tries)
+  !      New user function calling method
+  !      New build system generator (CMake)
+  !      Improved performance
   ! 4.3  New (test) functions : harmonic potential in 3D and loggamma
   !      Choice between different convergence methods : evidence or partition function
   ! 4.2  New search method added: uniform (around each live point) and slice sampling

--- a/src/nested_fit.f90
+++ b/src/nested_fit.f90
@@ -4,6 +4,7 @@ PROGRAM NESTED_FIT
   ! Please read README and LICENSE files for more inforamtion
   ! 4.4  OpenMPI support (only available for number of tries)
   !      New user function calling method
+  !      Add Windows support
   !      New build system generator (CMake)
   !      Improved performance
   ! 4.3  New (test) functions : harmonic potential in 3D and loggamma


### PR DESCRIPTION
- Add select to all the possible places it was applicable. (Tested in gauss_bg and ENERGY_HARM_3D, we will want to check all is OK!)
- Create the start of the changelog for 4.4 inside the `nested_fit.f90` file.
- Change the readme to accommodate for the OpenMPI and testing flags for CMake.
- Update the changelog in the readme (this can be automated!)
- Add a `SELECT` for the set and dimension number.